### PR TITLE
Save User after setting unusable password

### DIFF
--- a/djangooidc/backends.py
+++ b/djangooidc/backends.py
@@ -52,6 +52,7 @@ class OpenIdConnectBackend(ModelBackend):
             user, created = UserModel.objects.update_or_create(**args)
             if created:
                 user = self.configure_user(user, **kwargs)
+                user.save()
         else:
             try:
                 user = UserModel.objects.get_by_natural_key(username)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django_logingov_backend"
-version = "0.0.3"
+version = "0.0.5"
 authors = [
   { name="18F Developers", email="18fdev@gsa.gov" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django_logingov_backend',
-    version='0.0.3',
+    version='0.0.5',
     description='A Django OpenID Connect authentication backend designed for use with Login.gov',
     packages=find_packages(),
 )


### PR DESCRIPTION
As part of the first login / user creation process, we set an unusable password for the user because authentication is deferred to an external IDP.

This PR fixes a bug where the unusable password was set for the in-memory `User` object, but not persisted to the database, causing downstream issues in the Django sessions framework. 